### PR TITLE
Remove hash part of URL from request URL and client URL

### DIFF
--- a/packages/appcache-polyfill-sw/index.ts
+++ b/packages/appcache-polyfill-sw/index.ts
@@ -207,7 +207,10 @@ async function appCacheBehaviorForEvent(event: FetchEvent) {
     return fetch(event.request);
   }
 
-  const requestUrl = new URL(event.request.url);
+  const originalUrl = event.request.url;
+  const urlWithoutHash = originalUrl.split('#')[0];
+
+  const requestUrl = new URL(urlWithoutHash);
 
   // Appcache rules only apply to GETs & same-scheme requests.
   if (event.request.method !== 'GET' ||
@@ -215,7 +218,10 @@ async function appCacheBehaviorForEvent(event: FetchEvent) {
     return fetch(event.request);
   }
 
-  const clientUrl = await getClientUrlForEvent(event);
+  const originalClientUrl = await getClientUrlForEvent(event);
+  const clientUrlWithoutHash = originalClientUrl.split('#')[0];
+
+  const clientUrl = clientUrlWithoutHash;
   const pageURLToManifestURL: PageURLToManifestURL =
       await storage.get('PageURLToManifestURL');
   const manifestUrl = pageURLToManifestURL[clientUrl];


### PR DESCRIPTION
### Problem

Fragment identifiers (the hash part of the URL) are also [part of the service worker request URL](https://github.com/w3c/ServiceWorker/issues/854). This causes problems when using the `sw-appcache-behavior` AppCache polyfill with Single-Page Applications (SPA) because the URL including the fragment identifier does not match the URL cached from the manifest.

### Related

The same problem had already been identified in https://github.com/GoogleChrome/workbox/issues/488 and https://github.com/GoogleChromeLabs/sw-precache/issues/290.

### Solution

This pull request proposes a solution that seems to solve the problem in practical tests.

### Tests

The `sw-appcache-behavior` project already contains automated tests. However, they focus on the tricky part of populating the cache correctly from the manifest. There are currently no existing tests that check whether data is correctly retrieved back from the cache by the service worker.

Hence, we were not able to simply derive a test for the new behaviour proposed in the pull request.

Hopefully, the pull request can still help improve the `sw-appcache-behavior`.